### PR TITLE
✨ feat(spotify_tool): 재생 목록 재생 기능 추가

### DIFF
--- a/orchestrator/tools/spotify_tool.py
+++ b/orchestrator/tools/spotify_tool.py
@@ -175,3 +175,41 @@ def add_tracks_to_playlist(playlist_id: str, track_uris: List[str]) -> str:
         return "Tracks added successfully to playlist"
     except Exception as e:
         return f"Failed to add tracks to playlist: {str(e)}"
+
+
+# New function: play_playlist
+@mcp.tool()
+def play_playlist(playlist_id: str) -> str:
+    """
+    Start playback of a specified playlist.
+    
+    Args:
+        playlist_id: The Spotify ID of the playlist to play
+    
+    Returns:
+        Success message or error message
+    """
+    try:
+        # Get the current user's available devices
+        devices_response = make_spotify_request('GET', '/me/player/devices')
+        devices = devices_response.get('devices', [])
+        
+        if not devices:
+            return "No available devices found to start playback"
+        
+        # Use the first available active device
+        active_device = next((device for device in devices if device['is_active']), None)
+        if not active_device:
+            active_device = devices[0]
+        
+        device_id = active_device['id']
+        
+        # Start playback on the device with the given playlist
+        make_spotify_request('PUT', '/me/player/play', {
+            'context_uri': f'spotify:playlist:{playlist_id}',
+            'device_id': device_id
+        })
+        
+        return f"Playback started on device {active_device['name']}"
+    except Exception as e:
+        return f"Failed to start playback: {str(e)}"


### PR DESCRIPTION
- 사용자가 지정한 재생 목록을 재생하는 기능 추가
- 현재 사용 가능한 장치를 확인하고 첫 번째 활성 장치에서 재생 시작
- 활성 장치가 없는 경우 첫 번째 사용 가능한 장치 사용
- 예외 처리 및 오류 메시지 반환 기능 구현